### PR TITLE
Default to use curl utils

### DIFF
--- a/src/curl_httpfs_extension.cpp
+++ b/src/curl_httpfs_extension.cpp
@@ -104,6 +104,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	if (config.http_util && config.http_util->GetName() == "WasmHTTPUtils") {
 		// Already handled, do not override
 	} else {
+		// By default to use curl utils.
 		config.http_util = make_shared_ptr<HTTPFSCurlUtil>();
 	}
 

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -7,8 +7,6 @@
 #include <sys/stat.h>
 #include "duckdb/common/exception/http_exception.hpp"
 
-#include <iostream>
-
 namespace duckdb {
 
 // we statically compile in libcurl, which means the cert file location of the build machine is the


### PR DESCRIPTION
This PR updates default extension http utils to curl, instead of httplib; but still keep the update option to switch back to httplib.