### PR TITLE
[minor] Unify curl request struct

### DIFF
--- a/src/curl_request.cpp
+++ b/src/curl_request.cpp
@@ -10,6 +10,8 @@ CurlRequest::CurlRequest(std::string url) : info(make_uniq<RequestInfo>()) {
 	D_ASSERT(easy != nullptr);
 
 	curl_easy_setopt(easy_curl, CURLOPT_URL, info->url.c_str());
+	curl_easy_setopt(easy_curl, CURLOPT_HEADERFUNCTION, CurlRequest::WriteHeader);
+	curl_easy_setopt(easy_curl, CURLOPT_HEADERDATA, this);
 	curl_easy_setopt(easy_curl, CURLOPT_WRITEFUNCTION, CurlRequest::WriteBody);
 	curl_easy_setopt(easy_curl, CURLOPT_WRITEDATA, this);
 	curl_easy_setopt(easy_curl, CURLOPT_PRIVATE, this);
@@ -20,6 +22,42 @@ CurlRequest::CurlRequest(std::string url) : info(make_uniq<RequestInfo>()) {
 CurlRequest::~CurlRequest() {
 	D_ASSERT(easy_curl != nullptr);
 	curl_easy_cleanup(easy_curl);
+}
+
+/*static*/ size_t CurlRequest::WriteHeader(void *contents, size_t size, size_t nmemb, void *userp) {
+	size_t total_size = size * nmemb;
+	std::string header(static_cast<char *>(contents), total_size);
+	auto *req = static_cast<CurlRequest *>(userp);
+	auto &header_collection = req->info->header_collection;
+
+	// Trim trailing \r\n
+	if (!header.empty() && header.back() == '\n') {
+		header.pop_back();
+		if (!header.empty() && header.back() == '\r') {
+			header.pop_back();
+		}
+	}
+
+	// If header starts with HTTP/... curl has followed a redirect and we have a new Header,
+	// so we push back a new header_collection and store headers from the redirect there.
+	if (header.rfind("HTTP/", 0) == 0) {
+		header_collection.push_back(HTTPHeaders());
+		header_collection.back().Insert("__RESPONSE_STATUS__", header);
+	}
+
+	size_t colon_pos = header.find(':');
+
+	if (colon_pos != std::string::npos) {
+		// Split the string into two parts
+		std::string part1 = header.substr(0, colon_pos);
+		std::string part2 = header.substr(colon_pos + 1);
+		if (part2.at(0) == ' ') {
+			part2.erase(0, 1);
+		}
+
+		header_collection.back().Insert(part1, part2);
+	}
+	return total_size;
 }
 
 /*static*/ size_t CurlRequest::WriteBody(void *contents, size_t size, size_t nmemb, void *userp) {

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -5,6 +5,8 @@
 
 #include <curl/curl.h>
 #include <sys/stat.h>
+
+#include "curl_request.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 
 namespace duckdb {
@@ -37,6 +39,7 @@ static std::string SelectCURLCertPath() {
 
 static std::string cert_path = SelectCURLCertPath();
 
+// TODO(hjiang): Move content and header write callback to [`CurlRequest`].
 static size_t RequestWriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
 	size_t totalSize = size * nmemb;
 	std::string *str = static_cast<std::string *>(userp);
@@ -98,13 +101,6 @@ CURLHandle::CURLHandle(const string &token, const string &cert_path) {
 CURLHandle::~CURLHandle() {
 	curl_easy_cleanup(curl);
 }
-
-struct RequestInfo {
-	string url = "";
-	string body = "";
-	uint16_t response_code = 0;
-	std::vector<HTTPHeaders> header_collection;
-};
 
 static idx_t httpfs_client_count = 0;
 

--- a/src/include/curl_request.hpp
+++ b/src/include/curl_request.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <future>
+#include <vector>
 
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/common/map.hpp"
@@ -13,9 +14,10 @@
 namespace duckdb {
 
 struct RequestInfo {
-	string url;
-	string body;
+	string url = "";
+	string body = "";
 	uint16_t response_code = 0;
+	std::vector<HTTPHeaders> header_collection;
 };
 
 struct CurlRequest {
@@ -26,6 +28,7 @@ struct CurlRequest {
 	explicit CurlRequest(std::string url);
 	~CurlRequest();
 
+	static size_t WriteHeader(void *contents, size_t size, size_t nmemb, void *userp);
 	static size_t WriteBody(void *contents, size_t size, size_t nmemb, void *userp);
 };
 


### PR DESCRIPTION
This PR unifies curl request info, otherwise we have duplicate symbol.

```sql
D CREATE SECRET s3_secret(TYPE s3, KEY_ID 'xxx', SECRET 'yyy', REGION 'us-east-1');
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ true    │
└─────────┘
D SELECT length(content) AS char_count FROM read_text('s3://testing-kafka-local/_wal/test_db.test_local_100/metadata_wal.json');
┌────────────┐
│ char_count │
│   int64    │
├────────────┤
│    217     │
└────────────┘
```