### PR TITLE
Add kqueue and macos support

### DIFF
--- a/src/include/multi_curl_manager.hpp
+++ b/src/include/multi_curl_manager.hpp
@@ -15,7 +15,14 @@
 namespace duckdb {
 
 struct GlobalInfo {
+#ifdef __linux__
 	int epoll_fd = -1;
+	int timer_fd = -1;
+	int event_fd = -1;
+#elif defined(__APPLE__)
+	int kq_fd = -1;
+	int event_ident = -1;
+#endif
 	int timer_fd = -1;
 	int event_fd = -1;
 	CURLM *multi = nullptr;
@@ -39,7 +46,7 @@ public:
 private:
 	MultiCurlManager();
 
-	// Epoll-based eventloop.
+	// Eventloop implementation.
 	void HandleEvent();
 	// Process all pending requests and bind easy curl handle with multi curl handle.
 	void ProcessPendingRequests();


### PR DESCRIPTION
Currently polling engine only supports `epoll`, which is only available on linux;
this PR adds `kqueue` support, so the extension could be used in macos as well.

Testing:
```sh
hjiang@hjiangs-MacBook-Pro duckdb-curl-filesystem % make test_reldebug                                                                                                                
./build/reldebug/"/test/unittest" "test/*"
Filters: test/*
[1/1] (100%): test/sql/basic_http.test                                          
===============================================================================
All tests passed (1 assertion in 1 test case)
```