### PR TITLE
Add benchmark for httplib vs multi-curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ set(EXTENSION_SOURCES
     src/httpfs_curl_client.cpp
     src/httpfs_httplib_client.cpp
     src/multi_curl_manager.cpp
-    src/s3fs.cpp)
+    src/s3fs.cpp
+    src/thread_pool.cpp
+    src/thread_utils.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
@@ -49,8 +51,15 @@ install(
 # Test cases.
 include_directories(duckdb/third_party/catch)
 
+add_executable(test_thread_pool unit/test_thread_pool.cpp)
+target_link_libraries(test_thread_pool ${EXTENSION_NAME})
+
 add_executable(multi_curl_manager_test integration/multi_curl_manager_test.cpp)
 target_link_libraries(multi_curl_manager_test ${EXTENSION_NAME})
 
 add_executable(http_filesystem_test integration/http_filesystem_test.cpp)
 target_link_libraries(http_filesystem_test ${EXTENSION_NAME})
+
+# Benchmark
+add_executable(multicurl_benchmark benchmark/multicurl_benchmark.cpp)
+target_link_libraries(multicurl_benchmark ${EXTENSION_NAME})

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
 format-all: format
 	find integration/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
+	find benchmark/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	cmake-format -i CMakeLists.txt
 
 test_unit: all

--- a/benchmark/multicurl_benchmark.cpp
+++ b/benchmark/multicurl_benchmark.cpp
@@ -1,0 +1,92 @@
+// This benchmark compares the performance under heavy load read request, between httplib and multi-curl based
+// implementation.
+
+#include <array>
+#include <chrono>
+
+#include "duckdb.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/http_util.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_context_file_opener.hpp"
+#include "httpfs.hpp"
+#include "httpfs_client.hpp"
+#include "multi_curl_manager.hpp"
+#include "thread_pool.hpp"
+
+using namespace duckdb; // NOLINT
+
+// Spawn a number of threads for concurrent IO requests.
+constexpr size_t CONCURRENCY = 2000;
+// Test block sizes.
+constexpr std::array<idx_t, 7> TEST_BLOCK_SIZES = {16, 128, 1024, 8 * 1024, 64 * 1024, 512 * 1024, 2 * 1024 * 1024};
+
+// Handle single IO request: one HEAD request + one GET request.
+void HandleSingleRequest(ClientContextFileOpener *file_opener, idx_t start_offset, idx_t bytes_to_read,
+                         idx_t file_size) {
+	HTTPFileSystem fs {};
+	string url = "https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/main/test/data/stock-exchanges.csv";
+	auto file_handle = fs.OpenFile(url, FileOpenFlags::FILE_FLAGS_READ, file_opener);
+
+	bytes_to_read = std::min(bytes_to_read, file_size - start_offset);
+	string buffer(bytes_to_read, '\0');
+	file_handle->Read(static_cast<void *>(const_cast<char *>(buffer.data())), bytes_to_read, /*location=*/start_offset);
+}
+
+// Read a remote object via httpfs.
+void PerformBenchmarkImpl(shared_ptr<HTTPFSUtil> httpfs_util, idx_t block_size) {
+	DuckDB db(nullptr);
+	auto &instance = db.instance;
+	instance->config.http_util = make_shared_ptr<HTTPFSCurlUtil>();
+	auto client_context = make_shared_ptr<ClientContext>(instance);
+	client_context->transaction.BeginTransaction();
+	ClientContextFileOpener file_opener {*client_context};
+
+	HTTPFileSystem fs {};
+	string url = "https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/main/test/data/stock-exchanges.csv";
+	auto file_handle = fs.OpenFile(url, FileOpenFlags::FILE_FLAGS_READ, &file_opener);
+	const idx_t file_size = file_handle->GetFileSize();
+
+	ThreadPool tp {CONCURRENCY};
+	for (idx_t cur_start_offset = 0; cur_start_offset < file_size; cur_start_offset += block_size) {
+		tp.Push([cur_start_offset, &file_opener, block_size, file_size]() {
+			HandleSingleRequest(&file_opener, cur_start_offset, block_size, file_size);
+		});
+	}
+	tp.Wait();
+}
+
+// Benchmark httplib-based http filesystem.
+void BenchmarkHttplib(idx_t block_size) {
+	const auto start = std::chrono::steady_clock::now();
+	auto http_util = make_shared_ptr<HTTPFSUtil>();
+	PerformBenchmarkImpl(std::move(http_util), block_size);
+	const auto end = std::chrono::steady_clock::now();
+	auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+	std::cout << "httplib-based IO operation with block size " << block_size << " takes " << duration.count()
+	          << " milliseconds" << std::endl;
+}
+
+// Benchmark multi-curl-based http filesystem.
+void BenchmarkMultiCurl(idx_t block_size) {
+	const auto start = std::chrono::steady_clock::now();
+	auto http_util = make_shared_ptr<HTTPFSCurlUtil>();
+	PerformBenchmarkImpl(std::move(http_util), block_size);
+	const auto end = std::chrono::steady_clock::now();
+	auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+	std::cout << "multi-curl-based IO operation with block size " << block_size << " takes " << duration.count()
+	          << " milliseconds" << std::endl;
+}
+
+int main() {
+	for (idx_t cur_block_size : TEST_BLOCK_SIZES) {
+		BenchmarkHttplib(cur_block_size);
+		BenchmarkMultiCurl(cur_block_size);
+	}
+	return 0;
+}

--- a/benchmark/multicurl_benchmark.cpp
+++ b/benchmark/multicurl_benchmark.cpp
@@ -23,8 +23,11 @@ using namespace duckdb; // NOLINT
 
 // Spawn a number of threads for concurrent IO requests.
 constexpr size_t CONCURRENCY = 2000;
+// Benchmark iteration count.
+constexpr idx_t ITERATION_COUNT = 5;
 // Test block sizes.
-constexpr std::array<idx_t, 7> TEST_BLOCK_SIZES = {16, 128, 1024, 8 * 1024, 64 * 1024, 512 * 1024, 2 * 1024 * 1024};
+constexpr std::array<idx_t, 7> TEST_BLOCK_SIZES = {32,         256,         2 * 1024,       16 * 1024,
+                                                   128 * 1024, 1024 * 1024, 2 * 1024 * 1024};
 
 // Handle single IO request: one HEAD request + one GET request.
 void HandleSingleRequest(ClientContextFileOpener *file_opener, idx_t start_offset, idx_t bytes_to_read,
@@ -64,8 +67,10 @@ void PerformBenchmarkImpl(shared_ptr<HTTPFSUtil> httpfs_util, idx_t block_size) 
 // Benchmark httplib-based http filesystem.
 void BenchmarkHttplib(idx_t block_size) {
 	const auto start = std::chrono::steady_clock::now();
-	auto http_util = make_shared_ptr<HTTPFSUtil>();
-	PerformBenchmarkImpl(std::move(http_util), block_size);
+	for (idx_t ii = 0; ii < ITERATION_COUNT; ++ii) {
+		auto http_util = make_shared_ptr<HTTPFSUtil>();
+		PerformBenchmarkImpl(std::move(http_util), block_size);
+	}
 	const auto end = std::chrono::steady_clock::now();
 	auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 	std::cout << "httplib-based IO operation with block size " << block_size << " takes " << duration.count()
@@ -75,8 +80,10 @@ void BenchmarkHttplib(idx_t block_size) {
 // Benchmark multi-curl-based http filesystem.
 void BenchmarkMultiCurl(idx_t block_size) {
 	const auto start = std::chrono::steady_clock::now();
-	auto http_util = make_shared_ptr<HTTPFSCurlUtil>();
-	PerformBenchmarkImpl(std::move(http_util), block_size);
+	for (idx_t ii = 0; ii < ITERATION_COUNT; ++ii) {
+		auto http_util = make_shared_ptr<HTTPFSCurlUtil>();
+		PerformBenchmarkImpl(std::move(http_util), block_size);
+	}
 	const auto end = std::chrono::steady_clock::now();
 	auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 	std::cout << "multi-curl-based IO operation with block size " << block_size << " takes " << duration.count()

--- a/src/include/thread_pool.hpp
+++ b/src/include/thread_pool.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace duckdb {
+
+class ThreadPool {
+public:
+	ThreadPool();
+	explicit ThreadPool(size_t thread_num);
+
+	ThreadPool(const ThreadPool &) = delete;
+	ThreadPool &operator=(const ThreadPool &) = delete;
+
+	~ThreadPool() noexcept;
+
+	// @return future for synchronization.
+	template <typename Fn, typename... Args>
+	auto Push(Fn &&fn, Args &&...args) -> std::future<typename std::result_of<Fn(Args...)>::type>;
+
+	// Block until the threadpool is dead, or all enqueued tasks finish.
+	void Wait();
+
+private:
+	using Job = std::function<void(void)>;
+
+	size_t idle_num_ = 0;
+	bool stopped_ = false;
+	std::mutex mutex_;
+	std::condition_variable new_job_cv_;
+	std::condition_variable job_completion_cv_;
+	std::queue<Job> jobs_;
+	std::vector<std::thread> workers_;
+};
+
+template <typename Fn, typename... Args>
+auto ThreadPool::Push(Fn &&fn, Args &&...args) -> std::future<typename std::result_of<Fn(Args...)>::type> {
+	using Ret = typename std::result_of<Fn(Args...)>::type;
+
+	auto job =
+	    std::make_shared<std::packaged_task<Ret()>>(std::bind(std::forward<Fn>(fn), std::forward<Args>(args)...));
+	std::future<Ret> result = job->get_future();
+	{
+		std::lock_guard<std::mutex> lck(mutex_);
+		jobs_.emplace([job = std::move(job)]() mutable { (*job)(); });
+		new_job_cv_.notify_one();
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/src/include/thread_utils.hpp
+++ b/src/include/thread_utils.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+namespace duckdb {
+
+// Get the number of cores available to the system.
+// On linux platform, this function not only gets physical core number for CPU, but also considers available core number
+// within kubernetes pod, and container cgroup resource.
+int GetCpuCoreCount();
+
+} // namespace duckdb

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -1,0 +1,67 @@
+#include "thread_pool.hpp"
+
+#include <utility>
+
+#include "thread_utils.hpp"
+
+namespace duckdb {
+
+// TODO(hjiang): Doesn't work for cgroup.
+ThreadPool::ThreadPool() : ThreadPool(GetCpuCoreCount()) {
+}
+
+ThreadPool::ThreadPool(size_t thread_num) : idle_num_(thread_num) {
+	workers_.reserve(thread_num);
+	for (size_t ii = 0; ii < thread_num; ++ii) {
+		workers_.emplace_back([this]() {
+			for (;;) {
+				Job cur_job;
+				{
+					std::unique_lock<std::mutex> lck(mutex_);
+					new_job_cv_.wait(lck, [this]() { return !jobs_.empty() || stopped_; });
+					if (stopped_) {
+						return;
+					}
+					cur_job = std::move(jobs_.front());
+					jobs_.pop();
+					--idle_num_;
+				}
+
+				// Execute job out of critical section.
+				cur_job();
+
+				{
+					std::lock_guard<std::mutex> lck(mutex_);
+					++idle_num_;
+					job_completion_cv_.notify_one();
+				}
+			}
+		});
+	}
+}
+
+void ThreadPool::Wait() {
+	std::unique_lock<std::mutex> lck(mutex_);
+	job_completion_cv_.wait(lck, [this]() {
+		if (stopped_) {
+			return true;
+		}
+		if (idle_num_ == workers_.size() && jobs_.empty()) {
+			return true;
+		}
+		return false;
+	});
+}
+
+ThreadPool::~ThreadPool() noexcept {
+	{
+		std::lock_guard<std::mutex> lck(mutex_);
+		stopped_ = true;
+		new_job_cv_.notify_all();
+	}
+	for (auto &cur_worker : workers_) {
+		cur_worker.join();
+	}
+}
+
+} // namespace duckdb

--- a/src/thread_utils.cpp
+++ b/src/thread_utils.cpp
@@ -1,0 +1,24 @@
+#include "thread_utils.hpp"
+
+#include <pthread.h>
+#include <thread>
+
+#if defined(__linux__)
+#include <sched.h>
+#endif
+
+namespace duckdb {
+
+int GetCpuCoreCount() {
+#if defined(__APPLE__)
+	return std::thread::hardware_concurrency();
+#else
+	cpu_set_t cpuset;
+	CPU_ZERO(&cpuset);
+	sched_getaffinity(0, sizeof(cpuset), &cpuset);
+	const int core_count = CPU_COUNT(&cpuset);
+	return core_count;
+#endif
+}
+
+} // namespace duckdb

--- a/unit/test_thread_pool.cpp
+++ b/unit/test_thread_pool.cpp
@@ -1,0 +1,75 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include <future>
+
+#include "thread_pool.hpp"
+
+namespace {
+constexpr int kNumPromise = 10;
+void SetPromise(std::promise<void> *promise) {
+	promise->set_value();
+}
+int GetInputValue(int val) {
+	return val;
+}
+} // namespace
+
+using namespace duckdb; // NOLINT
+
+TEST_CASE("Threadpool test", "[threadpool]") {
+	// Enqueue lambda.
+	{
+		std::vector<std::promise<void>> promises(kNumPromise);
+		ThreadPool tp(1);
+		std::vector<std::future<void>> futures;
+		futures.reserve(kNumPromise);
+		for (int ii = 0; ii < kNumPromise; ++ii) {
+			auto func = [ii, &promises]() mutable {
+				promises[ii].set_value();
+			};
+			futures.emplace_back(tp.Push(std::move(func)));
+		}
+		tp.Wait();
+
+		for (int ii = 0; ii < kNumPromise; ++ii) {
+			promises[ii].get_future().get();
+		}
+	}
+
+	// Enqueue function with parameters.
+	{
+		std::vector<std::promise<void>> promises(kNumPromise);
+		ThreadPool tp(1);
+		std::vector<std::future<void>> futures;
+		futures.reserve(kNumPromise);
+		for (int ii = 0; ii < kNumPromise; ++ii) {
+			futures.emplace_back(tp.Push(SetPromise, &promises[ii]));
+		}
+		tp.Wait();
+
+		for (int ii = 0; ii < kNumPromise; ++ii) {
+			promises[ii].get_future().get();
+		}
+	}
+
+	// Enqueue function with return value.
+	{
+		ThreadPool tp(1);
+		std::vector<std::future<int>> futures;
+		futures.reserve(kNumPromise);
+		for (int val = 0; val < kNumPromise; ++val) {
+			futures.emplace_back(tp.Push(GetInputValue, val));
+		}
+		tp.Wait();
+
+		for (int val = 0; val < kNumPromise; ++val) {
+			REQUIRE(futures[val].get() == val);
+		}
+	}
+}
+
+int main(int argc, char **argv) {
+	int result = Catch::Session().run(argc, argv);
+	return result;
+}


### PR DESCRIPTION
This PR adds benchmark to compare performance between httplib vs multi-curl, to make sure the later's performance is no worse than httplib with additional features like connection pool.

```sh
httplib-based IO operation with block size 32 takes 34739 milliseconds
multi-curl-based IO operation with block size 32 takes 29298 milliseconds
httplib-based IO operation with block size 256 takes 2504 milliseconds
multi-curl-based IO operation with block size 256 takes 1597 milliseconds
httplib-based IO operation with block size 2048 takes 2515 milliseconds
multi-curl-based IO operation with block size 2048 takes 812 milliseconds
httplib-based IO operation with block size 16384 takes 656 milliseconds
multi-curl-based IO operation with block size 16384 takes 1359 milliseconds
httplib-based IO operation with block size 131072 takes 794 milliseconds
multi-curl-based IO operation with block size 131072 takes 775 milliseconds
httplib-based IO operation with block size 1048576 takes 661 milliseconds
multi-curl-based IO operation with block size 1048576 takes 1215 milliseconds
httplib-based IO operation with block size 2097152 takes 1160 milliseconds
multi-curl-based IO operation with block size 2097152 takes 1618 milliseconds
```
- Multi-curl performs well under high concurrency IO operations
- But doesn't look that correct for small concurrency situations, I need to double check