### PR TITLE
Provide option to enable and disable verbose logging

### DIFF
--- a/src/curl_httpfs_extension.cpp
+++ b/src/curl_httpfs_extension.cpp
@@ -3,6 +3,7 @@
 #include "httpfs_client.hpp"
 #include "create_secret_functions.hpp"
 #include "duckdb.hpp"
+#include "extension_config.hpp"
 #include "s3fs.hpp"
 #include "hffs.hpp"
 #ifdef OVERRIDE_ENCRYPTION_UTILS
@@ -107,6 +108,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 		// By default to use curl utils.
 		config.http_util = make_shared_ptr<HTTPFSCurlUtil>();
 	}
+
+	// Provide option to enable verbose logging for curl-based implementation.
+	auto callback_set_curl_verbose_logging = [](ClientContext &context, SetScope scope, Value &parameter) {
+		ENABLE_CURL_VERBOSE_LOGGING = parameter.GetValue<bool>();
+	};
+	config.AddExtensionOption("httpfs_curl_enable_verbose_logging",
+	                          "Turn on and off curl-based http util verbose logging.", LogicalType::BOOLEAN, false,
+	                          callback_set_curl_verbose_logging);
 
 	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
 	provider->SetAll();

--- a/src/curl_request.cpp
+++ b/src/curl_request.cpp
@@ -1,6 +1,7 @@
 #include "curl_request.hpp"
 
 #include "duckdb/common/assert.hpp"
+#include "extension_config.hpp"
 
 namespace duckdb {
 
@@ -10,8 +11,10 @@ CurlRequest::CurlRequest(CURL *easy_curl_p) : info(make_uniq<RequestInfo>()), ea
 	curl_easy_setopt(easy_curl, CURLOPT_WRITEFUNCTION, CurlRequest::WriteBody);
 	curl_easy_setopt(easy_curl, CURLOPT_WRITEDATA, this);
 	curl_easy_setopt(easy_curl, CURLOPT_PRIVATE, this);
-	// TODO(hjiang): Enable verbose logging when enabled.
-	// curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
+
+	if (ENABLE_CURL_VERBOSE_LOGGING) {
+		curl_easy_setopt(easy_curl, CURLOPT_VERBOSE, 1L);
+	}
 }
 
 CurlRequest::~CurlRequest() = default;

--- a/src/include/extension_config.hpp
+++ b/src/include/extension_config.hpp
@@ -1,0 +1,22 @@
+// This file contails curl-based http util config.
+
+#pragma once
+
+#include <atomic>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Default configuration
+//===--------------------------------------------------------------------===//
+
+inline constexpr bool DEFAULT_CURL_VERBOSE_LOGGING = false;
+
+//===--------------------------------------------------------------------===//
+// Global configuration
+//===--------------------------------------------------------------------===//
+
+// Whether to enable verbose logging for curl-based http util.
+inline std::atomic<bool> ENABLE_CURL_VERBOSE_LOGGING {DEFAULT_CURL_VERBOSE_LOGGING};
+
+} // namespace duckdb


### PR DESCRIPTION
This PR provides an option to enable/disable curl verbose logging.
```sql
D SET httpfs_curl_enable_verbose_logging=true;
D SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
* Host raw.githubusercontent.com:443 was resolved.
* IPv6: 2606:50c0:8001::154, 2606:50c0:8002::154, 2606:50c0:8003::154, 2606:50c0:8000::154
* IPv4: 185.199.110.133, 185.199.111.133, 185.199.108.133, 185.199.109.133
*   Trying [2606:50c0:8001::154]:443...
* Immediate connect fail for 2606:50c0:8001::154: Network is unreachable
*   Trying [2606:50c0:8002::154]:443...
* Immediate connect fail for 2606:50c0:8002::154: Network is unreachable
*   Trying [2606:50c0:8003::154]:443...
* Immediate connect fail for 2606:50c0:8003::154: Network is unreachable
*   Trying [2606:50c0:8000::154]:443...
* Immediate connect fail for 2606:50c0:8000::154: Network is unreachable
*   Trying 185.199.110.133:443...
* ALPN: curl offers h2,http/1.1
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519MLKEM768 / RSASSA-PSS
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.github.io
*  start date: Mar  7 00:00:00 2025 GMT
*  expire date: Mar  7 23:59:59 2026 GMT
*  subjectAltName: host "raw.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 1: Public key type RSA (2048/112 Bits/secBits), signed using sha384WithRSAEncryption
*   Certificate level 2: Public key type RSA (4096/152 Bits/secBits), signed using sha384WithRSAEncryption
* Connected to raw.githubusercontent.com (185.199.110.133) port 443
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv
* [HTTP/2] [1] [:method: HEAD]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: raw.githubusercontent.com]
* [HTTP/2] [1] [:path: /dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [accept-encoding: identity]
> HEAD /dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv HTTP/2
Host: raw.githubusercontent.com
Accept: */*
Accept-Encoding: identity

* Request completely sent off
< HTTP/2 200 
< cache-control: max-age=300
< content-security-policy: default-src 'none'; style-src 'unsafe-inline'; sandbox
< content-type: text/plain; charset=utf-8
< etag: "83eded75f3e83a2d5ac87d231cdc703f22ea93de08a419c6d4e70ad478825d0e"
< strict-transport-security: max-age=31536000
< x-content-type-options: nosniff
< x-frame-options: deny
< x-xss-protection: 1; mode=block
< x-github-request-id: BB4F:1F4BA6:1F4960:26B1FC:68E6F2DE
< accept-ranges: bytes
< date: Wed, 08 Oct 2025 23:25:19 GMT
< via: 1.1 varnish
< x-served-by: cache-pao-kpao1770024-PAO
< x-cache: MISS
< x-cache-hits: 0
< x-timer: S1759965919.291270,VS0,VE113
< vary: Authorization,Accept-Encoding
< access-control-allow-origin: *
< cross-origin-resource-policy: cross-origin
< x-fastly-request-id: ad2c09910b33fbe72084697ab461454e2cb18e5e
< expires: Wed, 08 Oct 2025 23:30:19 GMT
< source-age: 0
< content-length: 16222
< 
* Connection #0 to host raw.githubusercontent.com left intact
* Re-using existing https: connection with host raw.githubusercontent.com
* [HTTP/2] [3] OPENED stream for https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv
* [HTTP/2] [3] [:method: GET]
* [HTTP/2] [3] [:scheme: https]
* [HTTP/2] [3] [:authority: raw.githubusercontent.com]
* [HTTP/2] [3] [:path: /dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv]
* [HTTP/2] [3] [accept: */*]
* [HTTP/2] [3] [accept-encoding: identity]
> GET /dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv HTTP/2
Host: raw.githubusercontent.com
Accept: */*
Accept-Encoding: identity

* Request completely sent off
< HTTP/2 200 
< cache-control: max-age=300
< content-security-policy: default-src 'none'; style-src 'unsafe-inline'; sandbox
< content-type: text/plain; charset=utf-8
< etag: "83eded75f3e83a2d5ac87d231cdc703f22ea93de08a419c6d4e70ad478825d0e"
< strict-transport-security: max-age=31536000
< x-content-type-options: nosniff
< x-frame-options: deny
< x-xss-protection: 1; mode=block
< x-github-request-id: BB4F:1F4BA6:1F4960:26B1FC:68E6F2DE
< accept-ranges: bytes
< date: Wed, 08 Oct 2025 23:25:19 GMT
< via: 1.1 varnish
< x-served-by: cache-pao-kpao1770024-PAO
< x-cache: HIT
< x-cache-hits: 1
< x-timer: S1759965919.480049,VS0,VE1
< vary: Authorization,Accept-Encoding
< access-control-allow-origin: *
< cross-origin-resource-policy: cross-origin
< x-fastly-request-id: 72fe86123683173923972904ba61566656cd58a6
< expires: Wed, 08 Oct 2025 23:30:19 GMT
< source-age: 0
< content-length: 16222
< 
* Connection #0 to host raw.githubusercontent.com left intact
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│     251      │
└──────────────┘
```