### PR TITLE
Fix compilation and address warning on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(TARGET_NAME curl_httpfs)
 
 set(CMAKE_CXX_STANDARD 14)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++17-extensions")
+
 find_package(OpenSSL REQUIRED)
 find_package(CURL REQUIRED)
 

--- a/src/httpfs_curl_client.cpp
+++ b/src/httpfs_curl_client.cpp
@@ -116,7 +116,7 @@ public:
 	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) {
 		Initialize(http_params);
 	}
-	void Initialize(HTTPParams &http_p) override {
+	void Initialize(HTTPParams &http_p) {
 		HTTPFSParams &http_params = reinterpret_cast<HTTPFSParams &>(http_p);
 		auto bearer_token = "";
 		if (!http_params.bearer_token.empty()) {

--- a/src/httpfs_httplib_client.cpp
+++ b/src/httpfs_httplib_client.cpp
@@ -11,7 +11,7 @@ public:
 		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
 		Initialize(http_params);
 	}
-	void Initialize(HTTPParams &http_p) override {
+	void Initialize(HTTPParams &http_p) {
 		HTTPFSParams &http_params = reinterpret_cast<HTTPFSParams &>(http_p);
 		client->set_follow_location(http_params.follow_location);
 		client->set_keep_alive(http_params.keep_alive);


### PR DESCRIPTION
Compilation on macos gets
```sh
/Users/hjiang/Desktop/duckdb-curl-filesystem/src/tcp_connection_query_function.cpp:61:19: warning: decomposition declarations are a C++17 extension [-Wc++17-extensions]
   61 |         for (const auto &[cur_ip, cur_cnt] : tcp_connection_map) {
      |                          ^~~~~~~~~~~~~~~~~
/Users/hjiang/Desktop/duckdb-curl-filesystem/src/tcp_connection_query_function.cpp:128:19: warning: decomposition declarations are a C++17 extension [-Wc++17-extensions]
  128 |         for (const auto &[cur_ip, cur_cnt] : tcp_connection_map) {
      |                          ^~~~~~~~~~~~~~~~~
In file included from /Users/hjiang/Desktop/duckdb-curl-filesystem/src/curl_request.cpp:4:
/Users/hjiang/Desktop/duckdb-curl-filesystem/src/include/extension_config.hpp:13:1: warning: inline variables are a C++17 extension [-Wc++17-extensions]
   13 | inline constexpr bool DEFAULT_CURL_VERBOSE_LOGGING = false;
      | ^
/Users/hjiang/Desktop/duckdb-curl-filesystem/src/include/extension_config.hpp:20:1: warning: inline variables are a C++17 extension [-Wc++17-extensions]
   20 | inline std::atomic<bool> ENABLE_CURL_VERBOSE_LOGGING {DEFAULT_CURL_VERBOSE_LOGGING};
      | ^
/Users/hjiang/Desktop/duckdb-curl-filesystem/src/httpfs_curl_client.cpp:119:38: error: only virtual member functions can be marked 'override'
  119 |         void Initialize(HTTPParams &http_p) override {
      |                                             ^~~~~~~~
1 error generated.
make[3]: *** [extension/curl_httpfs/CMakeFiles/curl_httpfs_extension.dir/src/httpfs_curl_client.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
In file included from /Users/hjiang/Desktop/duckdb-curl-filesystem/src/curl_httpfs_extension.cpp:6:
/Users/hjiang/Desktop/duckdb-curl-filesystem/src/include/extension_config.hpp:13:1: warning: inline variables are a C++17 extension [-Wc++17-extensions]
   13 | inline constexpr bool DEFAULT_CURL_VERBOSE_LOGGING = false;
      | ^
/Users/hjiang/Desktop/duckdb-curl-filesystem/src/include/extension_config.hpp:20:1: warning: inline variables are a C++17 extension [-Wc++17-extensions]
   20 | inline std::atomic<bool> ENABLE_CURL_VERBOSE_LOGGING {DEFAULT_CURL_VERBOSE_LOGGING};
      | ^
/Users/hjiang/Desktop/duckdb-curl-filesystem/src/httpfs_httplib_client.cpp:14:38: error: only virtual member functions can be marked 'override'
   14 |         void Initialize(HTTPParams &http_p) override {
      |                                             ^~~~~~~~
```