### PR TITLE
Implement compatibility with httpfs extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(EXTENSION_SOURCES
     duckdb-httpfs/src/http_state.cpp
     duckdb-httpfs/src/httpfs.cpp
     duckdb-httpfs/src/httpfs_curl_client.cpp
+    duckdb-httpfs/src/httpfs_extension.cpp
     duckdb-httpfs/src/httpfs_httplib_client.cpp
     duckdb-httpfs/src/s3fs.cpp
     duckdb-httpfs/src/s3_multi_part_upload.cpp
@@ -71,6 +72,8 @@ target_link_libraries(http_filesystem_test ${EXTENSION_NAME} duckdb_static
                       dummy_static_extension_loader)
 
 # Benchmark
-add_executable(multicurl_benchmark benchmark/multicurl_benchmark.cpp)
-target_link_libraries(multicurl_benchmark ${EXTENSION_NAME} duckdb_static
-                      dummy_static_extension_loader)
+if(${BUILD_BENCHMARKS})
+  add_executable(multicurl_benchmark benchmark/multicurl_benchmark.cpp)
+  target_link_libraries(multicurl_benchmark ${EXTENSION_NAME} duckdb_static
+                        dummy_static_extension_loader)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,4 @@ format-all: format
 	find benchmark/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	cmake-format -i CMakeLists.txt
 
-test_unit: all
-	find build/release/extension/curl_httpfs/ -type f -name "*test*" -not -name "*.o" -not -name "*.cpp" -not -name "*.d" -exec {} \;
-
-test_reldebug_unit: reldebug
-	find build/reldebug/extension/curl_httpfs/ -type f -name "*test*" -not -name "*.o" -not -name "*.cpp" -not -name "*.d" -exec {} \;
-
-test_debug_unit: debug
-	find build/debug/extension/curl_httpfs/ -type f -name "*test*" -not -name "*.o" -not -name "*.cpp" -not -name "*.d" -exec {} \;
-
-PHONY: format-all test_unit test_reldebug_unit test_debug_unit
+PHONY: format-all

--- a/src/curl_httpfs_extension.cpp
+++ b/src/curl_httpfs_extension.cpp
@@ -1,157 +1,60 @@
 #include "curl_httpfs_extension.hpp"
 
-#include "create_secret_functions.hpp"
 #include "duckdb.hpp"
-#include "duckdb/common/local_file_system.hpp"
-#include "duckdb/main/client_context_file_opener.hpp"
 #include "extension_loader_helper.hpp"
 #include "hffs.hpp"
-#include "httpfs_curl_client.hpp"
+#include "httpfs_extension.hpp"
 #include "multi_curl_util.hpp"
 #include "s3fs.hpp"
-
-#ifdef OVERRIDE_ENCRYPTION_UTILS
-#include "crypto.hpp"
-#endif // OVERRIDE_ENCRYPTION_UTILS
 
 namespace duckdb {
 
 namespace {
 
+// "httpfs" extension name.
+constexpr const char *HTTPFS_EXTENSION = "httpfs";
+
+// Whether `httpfs` extension has already been loaded.
+bool IsHttpfsExtensionLoaded(DatabaseInstance &db_instance) {
+	auto &extension_manager = db_instance.GetExtensionManager();
+	const auto loaded_extensions = extension_manager.GetExtensions();
+	return std::find(loaded_extensions.begin(), loaded_extensions.end(), HTTPFS_EXTENSION) != loaded_extensions.end();
+}
+
+// Ensure httpfs extension is loaded, loading it if necessary
+void EnsureHttpfsExtensionLoaded(ExtensionLoader &loader, DatabaseInstance &instance) {
+	const bool httpfs_extension_loaded = IsHttpfsExtensionLoaded(instance);
+	if (httpfs_extension_loaded) {
+		return;
+	}
+	auto httpfs_extension = make_uniq<HttpfsExtension>();
+	httpfs_extension->Load(loader);
+
+	// Register into extension manager to keep compatibility as httpfs.
+	auto &extension_manager = ExtensionManager::Get(instance);
+	auto extension_active_load = extension_manager.BeginLoad(HTTPFS_EXTENSION);
+	// Manually fill in the extension install info to finalize extension load.
+	ExtensionInstallInfo extension_install_info;
+	extension_install_info.mode = ExtensionInstallMode::UNKNOWN;
+	extension_active_load->FinishLoad(extension_install_info);
+}
+
 void LoadInternal(ExtensionLoader &loader) {
 	auto &instance = loader.GetDatabaseInstance();
 	auto &fs = instance.GetFileSystem();
 
-	fs.RegisterSubSystem(make_uniq<HTTPFileSystem>());
-	fs.RegisterSubSystem(make_uniq<HuggingFaceFileSystem>());
-	fs.RegisterSubSystem(make_uniq<S3FileSystem>(BufferManager::GetBufferManager(instance)));
+	// To achieve full compatibility for duckdb-httpfs extension, all related functions/types/... should be supported,
+	// so we load it first if not already loaded.
+	EnsureHttpfsExtensionLoaded(loader, instance);
 
+	// Override the default HTTP util to MultiCurlUtil for this extension.
 	auto &config = DBConfig::GetConfig(instance);
-
-	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry (in seconds)",
-	                          LogicalType::UBIGINT, Value::UBIGINT(HTTPParams::DEFAULT_TIMEOUT_SECONDS));
-	config.AddExtensionOption("http_retries", "HTTP retries on I/O error", LogicalType::UBIGINT, Value(3));
-	config.AddExtensionOption("http_retry_wait_ms", "Time between retries", LogicalType::UBIGINT, Value(100));
-	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption("auto_fallback_to_full_download",
-	                          "Allows automatically falling back to full file downloads when possible.",
-	                          LogicalType::BOOLEAN, Value(true));
-	config.AddExtensionOption("http_retry_backoff", "Backoff factor for exponentially increasing retry wait time",
-	                          LogicalType::FLOAT, Value(4));
-	config.AddExtensionOption(
-	    "http_keep_alive",
-	    "Keep alive connections. Setting this to false can help when running into connection failures",
-	    LogicalType::BOOLEAN, Value(true));
-	config.AddExtensionOption("allow_asterisks_in_http_paths", "Allow '*' character in URLs users can query",
-	                          LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption("enable_curl_server_cert_verification",
-	                          "Enable server side certificate verification for CURL backend.", LogicalType::BOOLEAN,
-	                          Value(true));
-	config.AddExtensionOption("enable_server_cert_verification", "Enable server side certificate verification.",
-	                          LogicalType::BOOLEAN, Value(false));
-	auto callback_ca_cert_file = [](ClientContext &context, SetScope scope, Value &parameter) {
-		if (parameter.IsNull()) {
-			throw InvalidInputException("NULL it's not a valid option for ca_cert_file");
-		}
-		string value = StringValue::Get(parameter);
-		if (value.empty()) {
-			parameter = Value("");
-			return;
-		}
-		LocalFileSystem fs;
-		ClientContextFileOpener opener(context);
-		parameter = Value(fs.CanonicalizePath(value, opener));
-	};
-	config.AddExtensionOption("ca_cert_file", "Path to a custom certificate file for self-signed certificates.",
-	                          LogicalType::VARCHAR, Value(""), callback_ca_cert_file);
-
-	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_endpoint", "S3 Endpoint", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_url_style", "S3 URL style", LogicalType::VARCHAR, Value("vhost"));
-	config.AddExtensionOption("s3_use_ssl", "S3 use SSL", LogicalType::BOOLEAN, Value(true));
-	config.AddExtensionOption("s3_kms_key_id", "S3 KMS Key ID", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_url_compatibility_mode", "Disable Globs and Query Parameters on S3 URLs",
-	                          LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption("s3_requester_pays", "S3 use requester pays mode", LogicalType::BOOLEAN, Value(false));
-	config.AddExtensionOption(
-	    "s3_allow_recursive_globbing",
-	    "Whether globs on S3-like storage are optimized with recursive strategy (alterative is listing)",
-	    LogicalType::BOOLEAN, Value(true));
-
-	config.AddExtensionOption("s3_uploader_max_filesize", "S3 Uploader max filesize (between 50GB and 5TB)",
-	                          LogicalType::VARCHAR, "800GB");
-	config.AddExtensionOption("s3_uploader_max_parts_per_file", "S3 Uploader max parts per file (between 1 and 10000)",
-	                          LogicalType::UBIGINT, Value(10000));
-	config.AddExtensionOption("s3_uploader_thread_limit", "S3 Uploader global thread limit", LogicalType::UBIGINT,
-	                          Value(50));
-	config.AddExtensionOption("unsafe_disable_etag_checks", "Disable checks on ETag consistency", LogicalType::BOOLEAN,
-	                          Value(false));
-	config.AddExtensionOption("s3_version_id_pinning", "Pin S3 reads to a specific object version for consistency",
-	                          LogicalType::BOOLEAN, Value(false));
-
-	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",
-	                          LogicalType::UBIGINT, Value::UBIGINT(0));
-
-	config.AddExtensionOption("merge_http_secret_into_s3_request", "Merges http secret params into S3 requests",
-	                          LogicalType::BOOLEAN, Value(true));
-
-	auto callback_httpfs_client_implementation = [](ClientContext &context, SetScope scope, Value &parameter) {
-		auto &config = DBConfig::GetConfig(context);
-		string value = StringValue::Get(parameter);
-		if (config.http_util && config.http_util->GetName() == "WasmHTTPUtils") {
-			if (value == "wasm" || value == "default") {
-				return;
-			}
-			throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `wasm` and "
-			                            "`default` are currently supported for duckdb-wasm");
-		}
-		if (value == "multi_curl" || value == "default") {
-			if (!config.http_util || config.http_util->GetName() != "MultiCurl") {
-				config.http_util = make_shared_ptr<MultiCurlUtil>();
-			}
-			return;
-		}
-		if (value == "curl") {
-			if (!config.http_util || config.http_util->GetName() != "HTTPFSUtil-Curl") {
-				config.http_util = make_shared_ptr<HTTPFSCurlUtil>();
-			}
-			return;
-		}
-		if (value == "httplib") {
-			if (!config.http_util || config.http_util->GetName() != "HTTPFSUtil") {
-				config.http_util = make_shared_ptr<HTTPFSUtil>();
-			}
-			return;
-		}
-		throw InvalidInputException("Unsupported option for httpfs_client_implementation, only `multi_curl`, `curl`, "
-		                            "`httplib` and `default` are currently supported");
-	};
-	config.AddExtensionOption("httpfs_client_implementation", "Select which is the HTTPUtil implementation to be used",
-	                          LogicalType::VARCHAR, "default", callback_httpfs_client_implementation);
-	config.AddExtensionOption("enable_global_s3_configuration",
-	                          "Automatically fetch AWS credentials from environment variables.", LogicalType::BOOLEAN,
-	                          Value::BOOLEAN(true));
-
-	if (config.http_util && config.http_util->GetName() == "WasmHTTPUtils") {
-		// Already handled, do not override
-	} else {
+	if (!(config.http_util && config.http_util->GetName() == "WasmHTTPUtils")) {
 		config.http_util = make_shared_ptr<MultiCurlUtil>();
 	}
 
-	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
-	provider->SetAll();
-
-	CreateS3SecretFunctions::Register(loader);
-	CreateBearerTokenFunctions::Register(loader);
-
+	// Register curl_httpfs-specific functions and settings.
 	LoadExtensionInternal(loader);
-
-#ifdef OVERRIDE_ENCRYPTION_UTILS
-	config.encryption_util = make_shared_ptr<AESStateSSLFactory>();
-#endif // OVERRIDE_ENCRYPTION_UTILS
 }
 
 } // namespace

--- a/src/extension_loader_helper.cpp
+++ b/src/extension_loader_helper.cpp
@@ -1,7 +1,10 @@
 #include "extension_loader_helper.hpp"
 
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "extension_config.hpp"
+#include "httpfs_client.hpp"
+#include "multi_curl_util.hpp"
 #include "tcp_connection_query_function.hpp"
 #include "tcp_ip_recorder.hpp"
 
@@ -15,11 +18,61 @@ void ClearAllCache(const DataChunk &args, ExpressionState &state, Vector &result
 	TcpIpRecorder::GetInstance().Clear();
 	result.Reference(Value(SUCCESS));
 }
+
+// Get the name of the active HTTP util implementation.
+void GetHttpUtilName(const DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &config = DBConfig::GetConfig(*state.GetContext().db);
+	string name = config.http_util ? config.http_util->GetName() : "(None)";
+	result.Reference(Value(name));
+}
 } // namespace
 
 void LoadExtensionInternal(ExtensionLoader &loader) {
 	auto &instance = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(instance);
+
+	// Expose the active HTTP util implementation name for diagnostics and testing.
+	ScalarFunction http_util_name_function("curl_httpfs_http_util_name", /*arguments=*/ {},
+	                                       /*return_type=*/LogicalType {LogicalTypeId::VARCHAR}, GetHttpUtilName);
+	loader.RegisterFunction(std::move(http_util_name_function));
+
+	// Select the HTTP client implementation. Extends upstream httpfs with multi_curl support.
+	auto callback_httpfs_client_implementation = [](ClientContext &context, SetScope scope, Value &parameter) {
+		auto &config = DBConfig::GetConfig(context);
+		string value = StringValue::Get(parameter);
+		if (config.http_util && config.http_util->GetName() == "WasmHTTPUtils") {
+			if (value == "wasm" || value == "default") {
+				return;
+			}
+			throw InvalidInputException("Unsupported option for curl_httpfs_client_implementation, only `wasm` and "
+			                            "`default` are currently supported for duckdb-wasm");
+		}
+		if (value == "multi_curl" || value == "default") {
+			if (!config.http_util || config.http_util->GetName() != "MultiCurl") {
+				config.http_util = make_shared_ptr<MultiCurlUtil>();
+			}
+			return;
+		}
+		if (value == "curl") {
+			if (!config.http_util || config.http_util->GetName() != "HTTPFSUtil-Curl") {
+				config.http_util = make_shared_ptr<HTTPFSCurlUtil>();
+			}
+			return;
+		}
+		if (value == "httplib") {
+			if (!config.http_util || config.http_util->GetName() != "HTTPFSUtil") {
+				config.http_util = make_shared_ptr<HTTPFSUtil>();
+			}
+			return;
+		}
+		throw InvalidInputException("Unsupported option for curl_httpfs_client_implementation, only `multi_curl`, "
+		                            "`curl`, `httplib` and `default` are currently supported");
+	};
+	config.AddExtensionOption("curl_httpfs_client_implementation",
+	                          "Select the HTTPUtil implementation to be used. "
+	                          "Supports `multi_curl`, `curl`, `httplib`, and `default` (multi_curl).",
+	                          LogicalType {LogicalTypeId::VARCHAR}, "default",
+	                          std::move(callback_httpfs_client_implementation));
 
 	// Provide option to enable verbose logging for curl-based implementation.
 	auto callback_set_curl_verbose_logging = [](ClientContext &context, SetScope scope, Value &parameter) {
@@ -32,7 +85,7 @@ void LoadExtensionInternal(ExtensionLoader &loader) {
 	// Clear extension internal metrics collection.
 	ScalarFunction clear_cache_function("curl_httpfs_clear_metrics", /*arguments=*/ {},
 	                                    /*return_type=*/LogicalType {LogicalTypeId::BOOLEAN}, ClearAllCache);
-	loader.RegisterFunction(clear_cache_function);
+	loader.RegisterFunction(std::move(clear_cache_function));
 
 	// Register TCP connection status function.
 	loader.RegisterFunction(GetTcpConnectionNumFunc());

--- a/test/sql/attach_db.test
+++ b/test/sql/attach_db.test
@@ -1,0 +1,13 @@
+# name: test/sql/attach_db.test
+# description: test database file attachment
+# group: [sql]
+
+require curl_httpfs
+
+statement ok
+ATTACH 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/sample.duckdb' as db;
+
+query III
+SELECT database_name, schema_name, table_name FROM duckdb_tables() WHERE database_name = 'db';
+----
+db	main	users

--- a/test/sql/default_http_util.test
+++ b/test/sql/default_http_util.test
@@ -1,0 +1,10 @@
+# name: test/sql/default_http_util.test
+# description: test that the default HTTP util is MultiCurl
+# group: [sql]
+
+require curl_httpfs
+
+query I
+SELECT curl_httpfs_http_util_name();
+----
+MultiCurl

--- a/test/sql/http_util_switch.test
+++ b/test/sql/http_util_switch.test
@@ -6,7 +6,12 @@ require curl_httpfs
 
 # Default should be multi_curl
 statement ok
-SET httpfs_client_implementation='default';
+SET curl_httpfs_client_implementation='default';
+
+query I
+SELECT curl_httpfs_http_util_name();
+----
+MultiCurl
 
 query I
 SELECT length(content) > 0 FROM read_text('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/main/test/data/stock-exchanges.csv');
@@ -15,7 +20,12 @@ true
 
 # Switch to multi_curl explicitly
 statement ok
-SET httpfs_client_implementation='multi_curl';
+SET curl_httpfs_client_implementation='multi_curl';
+
+query I
+SELECT curl_httpfs_http_util_name();
+----
+MultiCurl
 
 query I
 SELECT length(content) > 0 FROM read_text('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/main/test/data/stock-exchanges.csv');
@@ -24,7 +34,12 @@ true
 
 # Switch to upstream curl (no multi-curl async)
 statement ok
-SET httpfs_client_implementation='curl';
+SET curl_httpfs_client_implementation='curl';
+
+query I
+SELECT curl_httpfs_http_util_name();
+----
+HTTPFS-Curl
 
 query I
 SELECT length(content) > 0 FROM read_text('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/main/test/data/stock-exchanges.csv');
@@ -33,7 +48,12 @@ true
 
 # Switch to httplib
 statement ok
-SET httpfs_client_implementation='httplib';
+SET curl_httpfs_client_implementation='httplib';
+
+query I
+SELECT curl_httpfs_http_util_name();
+----
+HTTPFS
 
 query I
 SELECT length(content) > 0 FROM read_text('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/main/test/data/stock-exchanges.csv');
@@ -42,7 +62,12 @@ true
 
 # Switch back to multi_curl
 statement ok
-SET httpfs_client_implementation='multi_curl';
+SET curl_httpfs_client_implementation='multi_curl';
+
+query I
+SELECT curl_httpfs_http_util_name();
+----
+MultiCurl
 
 query I
 SELECT length(content) > 0 FROM read_text('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/main/test/data/stock-exchanges.csv');
@@ -51,6 +76,6 @@ true
 
 # Invalid implementation should error
 statement error
-SET httpfs_client_implementation='nonexistent';
+SET curl_httpfs_client_implementation='nonexistent';
 ----
-Unsupported option for httpfs_client_implementation
+Unsupported option for curl_httpfs_client_implementation


### PR DESCRIPTION
One of the goals of the extension is to achieve 100% compatibility with httpfs extension, this PR registers httpfs internally and only register curl-httpfs-specific functions/types/secrets/settings/etc.