### PR TITLE
Fix HTTP error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ add_executable(http_filesystem_test integration/http_filesystem_test.cpp)
 target_link_libraries(http_filesystem_test ${EXTENSION_NAME} duckdb_static
                       dummy_static_extension_loader)
 
+add_subdirectory(test/unittest)
+
 # Benchmark
 if(${BUILD_BENCHMARKS})
   add_executable(multicurl_benchmark benchmark/multicurl_benchmark.cpp)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 format-all: format
 	find integration/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	find benchmark/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
+	find test/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	cmake-format -i CMakeLists.txt
 
 HTTPFS_TEST_TMPDIR := /tmp/curl-httpfs-duckdb-httpfs-test

--- a/src/multi_curl_manager.cpp
+++ b/src/multi_curl_manager.cpp
@@ -48,17 +48,27 @@ void CheckMulti(GlobalInfo *g) {
 		curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &response_code);
 		req->info->response_code = static_cast<uint16_t>(response_code);
 
+		const CURLcode res = msg->data.result;
 		HTTPStatusCode status_code = HTTPUtil::ToStatusCode(req->info->response_code);
 		auto resp = make_uniq<HTTPResponse>(status_code);
-		resp->body = req->info->body;
 		resp->url = req->info->url;
 		resp->reason = HTTPUtil::GetStatusMessage(status_code);
-		if (!req->info->header_collection.empty()) {
-			for (auto &header : req->info->header_collection.back()) {
-				if (header.first == "__RESPONSE_STATUS__") {
-					continue;
+		if (res != CURLcode::CURLE_OK) {
+			if (!req->info->header_collection.empty() &&
+			    req->info->header_collection.back().HasHeader("__RESPONSE_STATUS__")) {
+				resp->request_error = req->info->header_collection.back().GetHeaderValue("__RESPONSE_STATUS__");
+			} else {
+				resp->request_error = curl_easy_strerror(res);
+			}
+		} else {
+			resp->body = req->info->body;
+			if (!req->info->header_collection.empty()) {
+				for (auto &header : req->info->header_collection.back()) {
+					if (header.first == "__RESPONSE_STATUS__") {
+						continue;
+					}
+					resp->headers.Insert(header.first, header.second);
 				}
-				resp->headers.Insert(header.first, header.second);
 			}
 		}
 		req->response.set_value(std::move(resp));

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -1,0 +1,10 @@
+include_directories(${CMAKE_SOURCE_DIR}/src/include)
+include_directories(${CMAKE_SOURCE_DIR}/duckdb-httpfs/src/include)
+include_directories(${CMAKE_SOURCE_DIR}/duckdb/third_party/catch)
+
+set(CURL_HTTPFS_UNITTEST_OBJECTS main.cpp test_multi_curl_error.cpp)
+
+add_executable(unittest_curl_httpfs ${CURL_HTTPFS_UNITTEST_OBJECTS})
+
+target_link_libraries(unittest_curl_httpfs ${EXTENSION_NAME} duckdb_static
+                      dummy_static_extension_loader)

--- a/test/unittest/main.cpp
+++ b/test/unittest/main.cpp
@@ -1,0 +1,7 @@
+#define CATCH_CONFIG_RUNNER
+
+#include "catch.hpp"
+
+int main(int argc, char *argv[]) {
+	return Catch::Session().run(argc, argv);
+}

--- a/test/unittest/test_multi_curl_error.cpp
+++ b/test/unittest/test_multi_curl_error.cpp
@@ -1,0 +1,37 @@
+#include "catch.hpp"
+
+#include <curl/curl.h>
+
+#include "duckdb/common/http_util.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "httpfs_client.hpp"
+#include "multi_curl_client.hpp"
+#include "multi_curl_util.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+// Loopback port 1 is reserved and should have no listener — triggers CURLE_COULDNT_CONNECT quickly.
+constexpr const char *UNREACHABLE_URL = "http://127.0.0.1:1/";
+
+} // namespace
+
+TEST_CASE("MultiCurlClient surfaces libcurl errors on connection failure", "[multi_curl][error]") {
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+
+	MultiCurlUtil http_util;
+	HTTPFSParams params(http_util);
+	params.timeout = 1;
+	params.enable_curl_server_cert_verification = false;
+
+	MultiCurlClient client(params, "http://127.0.0.1:1");
+	HTTPHeaders headers;
+	GetRequestInfo request(UNREACHABLE_URL, headers, params, nullptr, nullptr);
+
+	auto response = client.Get(request);
+	REQUIRE(response != nullptr);
+	REQUIRE(response->HasRequestError());
+	REQUIRE_FALSE(response->GetRequestError().empty());
+}


### PR DESCRIPTION
In the current implementation, failed HTTP throws exceptions on the default path
https://github.com/duckdb/duckdb-httpfs/blob/c3f215ab360f04dc3d3d5305fa81849c0121f111/src/httpfs.cpp#L533-L534

This PR patches with better error message considering CURL return code.
```sql
memory D SELECT * FROM read_text('http://127.0.0.1:1/unreachable.csv');
IO Error:
Could not connect to server error for HTTP HEAD to 'http://127.0.0.1:1/unreachable.csv'
```